### PR TITLE
Improve desktop centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,27 +12,31 @@
 <body>
   <!-- ====== Header ====== -->
   <div class="header" role="banner">
-    <div class="logo" aria-label="Sanshi Gávea">
-      <img src="logosanshi.jpg" alt="Logo Sanshi Gávea" id="logoImg" />
-      <div class="brand">
-        <span class="title">Sanshi Gávea</span>
-        <span class="sub">Sushi • Sashimi • Combos</span>
+    <div class="header-inner">
+      <div class="logo" aria-label="Sanshi Gávea">
+        <img src="logosanshi.jpg" alt="Logo Sanshi Gávea" id="logoImg" />
+        <div class="brand">
+          <span class="title">Sanshi Gávea</span>
+          <span class="sub">Sushi • Sashimi • Combos</span>
+        </div>
       </div>
-    </div>
 
-    <div class="search-wrap">
-      <input id="searchInput" type="search" placeholder="Buscar item ou descrição..." aria-label="Buscar no cardápio">
-    </div>
+      <div class="search-wrap">
+        <input id="searchInput" type="search" placeholder="Buscar item ou descrição..." aria-label="Buscar no cardápio">
+      </div>
 
-    <div class="spacer"></div>
-    <div class="cart-mini" aria-live="polite">
-      <span>Itens</span>
-      <span class="badge" id="headerCount">0</span>
+      <div class="spacer"></div>
+      <div class="cart-mini" aria-live="polite">
+        <span>Itens</span>
+        <span class="badge" id="headerCount">0</span>
+      </div>
     </div>
   </div>
 
   <!-- ====== Categories Pills ====== -->
-  <nav class="categories" id="categories" aria-label="Categorias"></nav>
+  <nav class="categories" aria-label="Categorias">
+    <div class="categories-inner" id="categories"></div>
+  </nav>
 
   <!-- ====== Content ====== -->
   <main class="container" id="content"></main>

--- a/style.css
+++ b/style.css
@@ -31,7 +31,34 @@ h1,h2,h3{font-family:Marcellus,serif; letter-spacing:.2px}
 /* Header */
 .header{
   position:sticky; top:0; z-index:100; background:var(--card); border-bottom:1px solid var(--line);
-  display:flex; align-items:center; gap:12px; padding:10px 16px;
+  padding:10px 0; box-shadow:var(--shadow-soft);
+}
+.header-inner{
+  width:100%; max-width:1200px; margin:0 auto; padding:0 14px;
+  display:flex; align-items:center; gap:16px;
+}
+.search-wrap{flex:1; display:flex; justify-content:center;}
+.search-wrap input{
+  width:100%; max-width:460px; border-radius:999px; border:1px solid var(--line);
+  padding:10px 16px; background:#f1f3f5; color:var(--ink);
+  transition:border-color .2s ease, box-shadow .2s ease;
+}
+.search-wrap input:focus{
+  outline:none; border-color:var(--brand); box-shadow:var(--focus);
+}
+@media (prefers-color-scheme:dark){
+  .search-wrap input{background:#171a1d; border-color:#1f252b; color:var(--ink);}
+}
+.header .spacer{flex:1}
+.header .cart-mini{justify-content:flex-end}
+@media (max-width: 720px){
+  .header-inner{flex-wrap:wrap; gap:12px 16px;}
+  .header .spacer{display:none}
+  .header .cart-mini{margin-left:auto}
+  .search-wrap{order:3; flex-basis:100%;}
+}
+@media (min-width: 1024px){
+  .header-inner,.categories-inner{padding:0 24px;}
 }
 .header .logo{display:flex; align-items:center; gap:10px}
 .header .logo img{height:36px; width:auto; border-radius:10px; background:#fff}
@@ -47,23 +74,30 @@ h1,h2,h3{font-family:Marcellus,serif; letter-spacing:.2px}
 
 /* Categories */
 .categories{
-  position:sticky; top:58px; z-index:90; background:var(--card); border-bottom:1px solid var(--line);
-  padding:10px 12px; display:flex; gap:8px; overflow:auto; scrollbar-width:none;
+  position:sticky; top:78px; z-index:90; background:var(--card); border-bottom:1px solid var(--line);
+  padding:10px 0; box-shadow:var(--shadow-soft);
 }
-.categories::-webkit-scrollbar{display:none}
-.categories a{
+.categories-inner{
+  max-width:1200px; margin:0 auto; padding:0 14px;
+  display:flex; gap:8px; overflow:auto; scrollbar-width:none;
+}
+.categories-inner::-webkit-scrollbar{display:none}
+.categories-inner a{
   text-decoration:none; color:#111; background:#f1f3f5; border:1px solid #e6e8eb;
   padding:8px 12px; border-radius:999px; white-space:nowrap; font-weight:700; font-size:13px;
 }
-.categories a:hover{filter:brightness(.98)}
-.categories a.active{background:var(--brand); color:#fff; border-color:var(--brand)}
+.categories-inner a:hover{filter:brightness(.98)}
+.categories-inner a.active{background:var(--brand); color:#fff; border-color:var(--brand)}
 @media (prefers-color-scheme:dark){
-  .categories a{background:#171a1d; border-color:#1f252b; color:var(--ink)}
+  .categories-inner a{background:#171a1d; border-color:#1f252b; color:var(--ink)}
+}
+@media (max-width: 720px){
+  .categories{top:64px;}
 }
 
 /* Sections */
 .container{padding:18px 14px 100px; max-width:1200px; margin:0 auto;}
-.section{scroll-margin-top:120px; padding:8px 0}
+.section{scroll-margin-top:150px; padding:8px 0}
 .section h2{margin:6px 4px 12px; font-size:22px}
 .grid{
   display:grid; gap:14px;


### PR DESCRIPTION
## Summary
- wrap the header content with an inner container so the logo, busca e carrinho fiquem alinhados ao centro em telas grandes
- centralize a faixa de categorias dentro de um limite de largura e ajuste o deslocamento para desktop e mobile
- estilize o campo de busca para ficar coerente com o restante do layout e reorganize o cabeçalho em telas pequenas

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ca03b918d0832b97b557bbf188fb32